### PR TITLE
Migration to a PSR-15 Middleware for Flow 8 compatibility

### DIFF
--- a/Classes/HttpMetricsCollectorComponent.php
+++ b/Classes/HttpMetricsCollectorComponent.php
@@ -34,14 +34,6 @@ class HttpMetricsCollectorComponent implements MiddlewareInterface
         $this->collectorRegistry = $collectorRegistry;
     }
 
-    /**
-     * Process an incoming server request and return a response, optionally delegating
-     * response creation to a handler.
-     *
-     * @param ServerRequestInterface $request
-     * @param RequestHandlerInterface $handler
-     * @return ResponseInterface
-     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         // Handle the request and get the response from the next middleware in the chain

--- a/Configuration/Settings.Http.yaml
+++ b/Configuration/Settings.Http.yaml
@@ -1,10 +1,7 @@
 Neos:
   Flow:
     http:
-      chain:
-        'postprocess':
-          chain:
-            'Flownative.Prometheus:metricsExporter':
-              'position': 'end'
-              component: 'Flownative\Prometheus\FlowMetrics\HttpMetricsCollectorComponent'
-              componentOptions: []
+      middlewares:
+        'metrics':
+          position: 'before routing'
+          middleware: 'Flownative\Prometheus\FlowMetrics\HttpMetricsCollectorComponent'

--- a/Configuration/Settings.Http.yaml
+++ b/Configuration/Settings.Http.yaml
@@ -3,5 +3,5 @@ Neos:
     http:
       middlewares:
         'metrics':
-          position: 'end'
+          position: 'start'
           middleware: 'Flownative\Prometheus\FlowMetrics\HttpMetricsCollectorComponent'

--- a/Configuration/Settings.Http.yaml
+++ b/Configuration/Settings.Http.yaml
@@ -3,5 +3,5 @@ Neos:
     http:
       middlewares:
         'metrics':
-          position: 'before routing'
+          position: 'end'
           middleware: 'Flownative\Prometheus\FlowMetrics\HttpMetricsCollectorComponent'

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "flownative/prometheus-flow-metrics",
-    "license": "MIT",
     "type": "neos-package",
     "description": "Prometheus metrics for Neos Flow applications",
+    "license": "MIT",
     "authors": [
         {
             "name": "Robert Lemke",
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "neos/flow": "5.* || 6.* || @dev",
+        "neos/flow": "7.* || 8.* || @dev",
         "flownative/prometheus": "0.* || @dev"
     },
     "suggest": {


### PR DESCRIPTION
This PR solves https://github.com/flownative/flow-prometheus-flow-metrics/issues/2 and makes it usable for Flow 8+.

Info: **Not** tested with any other flow / neos version.  The composer.json has been adjusted by _guessing_ of what version could be compatible with the changes.

Output of e.g. `https://host/metrics:`

```bash
# HELP neos_flow_http_requests_total Number of HTTP requests processed by Flow's HTTP stack
# TYPE neos_flow_http_requests_total counter
neos_flow_http_requests_total{status="200"} 5

# HELP neos_flow_sessions Number of Flow sessions
# TYPE neos_flow_sessions gauge
neos_flow_sessions{state="active"} 1
```

Tested with [neos/neos 8.3.17](https://github.com/neos/neos-development-collection/releases/tag/8.3.17) / [neos/flow 8.3.11](https://github.com/neos/flow-development-collection/releases/tag/8.3.11) / [8.3.12-fpm-alpine3.20](https://hub.docker.com/layers/library/php/8.3.12-fpm-alpine3.20/images/sha256-9c39753ffc1544ccac45560a1ff97936c67e660af735f592be3119b5495c698e?context=explore)